### PR TITLE
Apply dependency upgrades from refreshVersions and fix tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(Testing.kotest.runner.junit5)
     testImplementation(Testing.kotest.assertions.core)
+    testImplementation(KotlinX.coroutines.test)
 }
 
 tasks.test {

--- a/buildSrc/src/main/kotlin/Ci.kt
+++ b/buildSrc/src/main/kotlin/Ci.kt
@@ -2,7 +2,7 @@
 object Ci {
     // this is the version used for building snapshots
     // .GITHUB_RUN_NUMBER-snapshot will be appended
-    private const val snapshotBase = "2.0.0"
+    private const val snapshotBase = "2.0.1"
 
     private val githubRunNumber = System.getenv("GITHUB_RUN_NUMBER")
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### 2.0.1
+* Updated dependency and plugin versions using `./gradlew refreshVersions` (including Bucket4j 8.16.1, Kotlin 2.3.10, Kotest 6.1.3, and coroutines 1.10.2).
+* Bumped package version from `2.0.0` to `2.0.1`.
+
 #### 2.0.0
 * Updated to build for JDK17 ahead of the OpenJDK 11 EOL date.
 * Updated dependencies

--- a/src/main/kotlin/com/sletmoe/bucket4k/SuspendingBucket.kt
+++ b/src/main/kotlin/com/sletmoe/bucket4k/SuspendingBucket.kt
@@ -13,7 +13,9 @@ import kotlin.time.Duration
  * Whereas Bucket4j's blocking behavior is just that, [SuspendingBucket] instead delays, making it safe to use in a
  * coroutine context.
  */
-class SuspendingBucket private constructor(private val impl: SuspendingBucketImpl) {
+class SuspendingBucket private constructor(
+    private val impl: SuspendingBucketImpl,
+) {
     /**
      * Delegates directly to the underlying LockFreeBucket's toString implementation.
      */

--- a/versions.properties
+++ b/versions.properties
@@ -9,9 +9,9 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
-plugin.org.jlleitschuh.gradle.ktlint=12.1.1
+plugin.org.jlleitschuh.gradle.ktlint=14.0.1
 
-version.com.bucket4j..bucket4j_jdk17-core=8.14.0
+version.com.bucket4j..bucket4j_jdk17-core=8.16.1
 
 ## unused
 version.io.github.oshai..kotlin-logging=5.1.0
@@ -34,14 +34,16 @@ version.org.jetbrains.dokka..dokka-base=1.9.20
 ## unused
 version.org.jetbrains.dokka..analysis-kotlin-descriptors=1.9.20
 
-version.kotlin=2.0.21
+version.kotlin=2.3.10
 
-plugin.org.jetbrains.dokka=1.9.20
+plugin.org.jetbrains.dokka=2.1.0
 
 plugin.io.github.gradle-nexus.publish-plugin=2.0.0
 
-plugin.de.fayard.buildSrcLibs=0.60.5
+## unused
+plugin.de.fayard.buildSrcLibs=0.60.6
+##                # available=0.60.6
 
-version.kotest=5.9.1
+version.kotest=6.1.3
 
-version.kotlinx.coroutines=1.9.0
+version.kotlinx.coroutines=1.10.2


### PR DESCRIPTION
### Motivation
- The prior change only recorded availability comments from `refreshVersions` rather than applying the upgraded versions, leaving the project using older dependencies and causing test breakage with newer metadata.

### Description
- Updated `versions.properties` to apply the actual version bumps surfaced by `./gradlew refreshVersions` (notably `com.bucket4j:bucket4j_jdk17-core` -> `8.16.1`, Kotlin -> `2.3.10`, Kotest -> `6.1.3`, kotlinx.coroutines -> `1.10.2`, ktlint plugin -> `14.0.1`, and Dokka plugin -> `2.1.0`).
- Added `testImplementation(KotlinX.coroutines.test)` to `build.gradle.kts` so tests compile against the updated coroutines/Kotest stack.
- Bumped the snapshot base version in `buildSrc/src/main/kotlin/Ci.kt` from `2.0.0` to `2.0.1` so CI snapshot versions advance.
- Clarified the `2.0.1` entry in `changelog.md` to reflect that versions were actually upgraded by `refreshVersions`.

### Testing
- Ran `export JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2; ./gradlew refreshVersions` which completed successfully.
- Ran `export JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2; ./gradlew test` which completed successfully and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981212aa708330abbedcaa99531eb7)