### PR TITLE
Migrate Dokka to v2 DSL and bump project to 3.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
-import org.jetbrains.dokka.DokkaConfiguration.Visibility
-import org.jetbrains.dokka.Platform
-import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import java.net.URL
 
 plugins {
@@ -45,51 +43,51 @@ java {
 
 kotlin {
     compilerOptions {
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3)
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 
-tasks.withType<DokkaTask>().configureEach {
+dokka {
     moduleName.set(project.name)
     moduleVersion.set(project.version.toString())
-    outputDirectory.set(layout.buildDirectory.dir("dokka/$name"))
-    failOnWarning.set(false)
-    suppressObviousFunctions.set(true)
-    suppressInheritedMembers.set(false)
-    offlineMode.set(false)
 
-    dokkaSourceSets {
-        configureEach {
-            documentedVisibilities.set(setOf(Visibility.PUBLIC))
-            reportUndocumented.set(false)
-            skipEmptyPackages.set(true)
+    dokkaPublications.html {
+        outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
+        failOnWarning.set(false)
+        suppressObviousFunctions.set(true)
+        suppressInheritedMembers.set(false)
+        offlineMode.set(false)
+    }
+
+    dokkaSourceSets.main {
+        documentedVisibilities.set(setOf(VisibilityModifier.Public))
+        reportUndocumented.set(false)
+        skipEmptyPackages.set(true)
+        skipDeprecated.set(false)
+        suppressGeneratedFiles.set(true)
+        jdkVersion.set(17)
+        languageVersion.set("17")
+        apiVersion.set("17")
+        enableKotlinStdLibDocumentationLink.set(true)
+        enableJdkDocumentationLink.set(true)
+        sourceRoots.from(file("src"))
+
+        sourceLink {
+            localDirectory.set(projectDir.resolve("src"))
+            remoteUrl.set(URL("https://github.com/ksletmoe/Bucket4k/tree/mainline/src").toURI())
+            remoteLineSuffix.set("#L")
+        }
+
+        perPackageOption {
+            suppress.set(false)
             skipDeprecated.set(false)
-            suppressGeneratedFiles.set(true)
-            jdkVersion.set(17)
-            languageVersion.set("17")
-            apiVersion.set("17")
-            noStdlibLink.set(false)
-            noJdkLink.set(false)
-            platform.set(Platform.DEFAULT)
-            sourceRoots.from(file("src"))
-
-            sourceLink {
-                localDirectory.set(projectDir.resolve("src"))
-                remoteUrl.set(URL("https://github.com/ksletmoe/Bucket4k/tree/mainline/src"))
-                remoteLineSuffix.set("#L")
-            }
-
-            perPackageOption {
-                suppress.set(false)
-                skipDeprecated.set(false)
-                reportUndocumented.set(false)
-                documentedVisibilities.set(
-                    setOf(
-                        Visibility.PUBLIC,
-                    ),
-                )
-            }
+            reportUndocumented.set(false)
+            documentedVisibilities.set(
+                setOf(
+                    VisibilityModifier.Public,
+                ),
+            )
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Ci.kt
+++ b/buildSrc/src/main/kotlin/Ci.kt
@@ -2,7 +2,7 @@
 object Ci {
     // this is the version used for building snapshots
     // .GITHUB_RUN_NUMBER-snapshot will be appended
-    private const val snapshotBase = "2.0.1"
+    private const val snapshotBase = "3.0.0"
 
     private val githubRunNumber = System.getenv("GITHUB_RUN_NUMBER")
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### 3.0.0
+* Migrated Dokka configuration to the Dokka Gradle plugin v2 DSL and enabled Dokka v2 mode to remove deprecated v1 task usage.
+* Updated Kotlin compiler API version targeting to Kotlin 2.3.
+* Bumped package version from `2.0.1` to `3.0.0`.
+
 #### 2.0.1
 * Updated dependency and plugin versions using `./gradlew refreshVersions` (including Bucket4j 8.16.1, Kotlin 2.3.10, Kotest 6.1.3, and coroutines 1.10.2).
 * Bumped package version from `2.0.0` to `2.0.1`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
### Motivation

- Dokka usage in `build.gradle.kts` relied on the deprecated V1 task API (`DokkaTask`) which triggers a deprecation warning and will be removed in Dokka v2.2.0.  
- Kotlin compiler API targeting should be upgraded to the requested Kotlin 2.3 series.  
- The library release requires a major version bump and an entry in the changelog to reflect the migration.

### Description

- Replaced the deprecated V1 Dokka task configuration with the Dokka v2 top-level `dokka {}` DSL and publication configuration in `build.gradle.kts`, converting source-set and publication properties to the v2 equivalents (e.g. `dokkaPublications`, `dokkaSourceSets.main`, `VisibilityModifier`, `enableKotlinStdLibDocumentationLink`, `enableJdkDocumentationLink`, and using `URI` for `remoteUrl`).  
- Updated Kotlin compiler API target from `KOTLIN_2_0` to `KOTLIN_2_3` in the Gradle Kotlin configuration.  
- Enabled Dokka v2 mode by adding `org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled` to `gradle.properties`.  
- Bumped the snapshot base version to `3.0.0` in `buildSrc/src/main/kotlin/Ci.kt` and added a `3.0.0` entry to `changelog.md`.  
- Files modified: `build.gradle.kts`, `gradle.properties`, `buildSrc/src/main/kotlin/Ci.kt`, `changelog.md`.

### Testing

- Ran `./gradlew test dokkaGeneratePublicationHtml` after forcing `JAVA_HOME` to a Java 17 installation; the final automated build completed successfully.  
- The initial `./gradlew` run failed due to the environment using Java 25, which was resolved by running with `JAVA_HOME` set to Java 17 before re-running the Gradle command.  
- Dokka produced non-fatal warnings about unresolved external `package-list` downloads and one unresolved symbol link, but the `test` and `dokkaGeneratePublicationHtml` tasks completed and the build returned `SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699819e1fa0c8330a732988b6d84ba84)