### PR TITLE
Update Sonatype repository URLs for nexus publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,8 +101,8 @@ tasks.register("dokkaHtml") {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
## Summary
Updates the Sonatype repository URLs used for publishing artifacts via the nexus publishing plugin to use the new Central Repository endpoints.

## Key Changes
- Updated `nexusUrl` from `https://s01.oss.sonatype.org/service/local/` to `https://ossrh-staging-api.central.sonatype.com/service/local/`
- Updated `snapshotRepositoryUrl` from `https://s01.oss.sonatype.org/repositories/snapshots/` to `https://central.sonatype.com/repository/maven-snapshots/`

## Details
These changes align with Sonatype's migration to the new Central Repository infrastructure. The updated URLs point to the new API endpoints for publishing releases and snapshots.

https://claude.ai/code/session_01DwyAdQfnkFXo1GPa7LGNpm