### PR TITLE
Fix snapshot publishing 403 by using Bearer token auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Publish to Sonatype
+      - name: Publish Snapshot to Central Portal
         env:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
-        run: ./gradlew publishToSonatype --no-daemon
+        run: ./gradlew publishMavenJavaPublicationToCentralPortalSnapshotsRepository --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import java.net.URL
+import java.util.Base64
 
 plugins {
     kotlin("jvm")
@@ -107,7 +108,26 @@ nexusPublishing {
     }
 }
 
+val sonatypeUsername: String? by project
+val sonatypePassword: String? by project
+
 publishing {
+    repositories {
+        if (Ci.isRelease.not() && sonatypeUsername != null && sonatypePassword != null) {
+            maven {
+                name = "centralPortalSnapshots"
+                url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+                credentials(HttpHeaderCredentials::class) {
+                    name = "Authorization"
+                    value = "Bearer ${Base64.getEncoder().encodeToString("$sonatypeUsername:$sonatypePassword".toByteArray())}"
+                }
+                authentication {
+                    create<HttpHeaderAuthentication>("header")
+                }
+            }
+        }
+    }
+
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,7 +120,8 @@ publishing {
                 credentials(HttpHeaderCredentials::class) {
                     name = "Authorization"
                     val credentials = "$sonatypeUsername:$sonatypePassword"
-                    val encoded = Base64.getEncoder()
+                    val encoded = Base64
+                        .getEncoder()
                         .encodeToString(credentials.toByteArray())
                     value = "Bearer $encoded"
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,10 @@ publishing {
                 url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                 credentials(HttpHeaderCredentials::class) {
                     name = "Authorization"
-                    value = "Bearer ${Base64.getEncoder().encodeToString("$sonatypeUsername:$sonatypePassword".toByteArray())}"
+                    val credentials = "$sonatypeUsername:$sonatypePassword"
+                    val encoded = Base64.getEncoder()
+                        .encodeToString(credentials.toByteArray())
+                    value = "Bearer $encoded"
                 }
                 authentication {
                     create<HttpHeaderAuthentication>("header")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,11 +119,9 @@ publishing {
                 url = uri("https://central.sonatype.com/repository/maven-snapshots/")
                 credentials(HttpHeaderCredentials::class) {
                     name = "Authorization"
-                    val credentials = "$sonatypeUsername:$sonatypePassword"
-                    val encoded = Base64
-                        .getEncoder()
-                        .encodeToString(credentials.toByteArray())
-                    value = "Bearer $encoded"
+                    val token = "$sonatypeUsername:$sonatypePassword"
+                    value =
+                        "Bearer ${Base64.getEncoder().encodeToString(token.toByteArray())}"
                 }
                 authentication {
                     create<HttpHeaderAuthentication>("header")


### PR DESCRIPTION
The Central Portal snapshot repository requires Bearer token authentication, but the nexus-publish-plugin sends Basic Auth credentials. This adds a separate Maven repository with proper HttpHeaderCredentials/Bearer auth for snapshot publishing, bypassing the nexus-publish-plugin for snapshots.

https://claude.ai/code/session_01DwyAdQfnkFXo1GPa7LGNpm