### PR TITLE
Simplify Sonatype Maven repository authentication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import java.net.URL
-import java.util.Base64
 
 plugins {
     kotlin("jvm")
@@ -117,14 +116,9 @@ publishing {
             maven {
                 name = "centralPortalSnapshots"
                 url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-                credentials(HttpHeaderCredentials::class) {
-                    name = "Authorization"
-                    val token = "$sonatypeUsername:$sonatypePassword"
-                    value =
-                        "Bearer ${Base64.getEncoder().encodeToString(token.toByteArray())}"
-                }
-                authentication {
-                    create<HttpHeaderAuthentication>("header")
+                credentials {
+                    username = sonatypeUsername
+                    password = sonatypePassword
                 }
             }
         }


### PR DESCRIPTION
## Summary
Simplified the authentication mechanism for the Sonatype Maven Central Portal snapshots repository by switching from custom HTTP header-based authentication to standard Maven credentials.

## Key Changes
- Removed `Base64` import that was only used for manual token encoding
- Replaced custom `HttpHeaderCredentials` with standard Maven `credentials` block
- Changed from Bearer token authentication to basic username/password authentication
- Removed explicit `HttpHeaderAuthentication` configuration
- Credentials now use `sonatypeUsername` and `sonatypePassword` properties directly

## Implementation Details
The authentication now leverages Maven's built-in credential handling instead of manually constructing Base64-encoded Bearer tokens. This approach is simpler, more maintainable, and aligns with standard Maven repository authentication practices. The credentials are still sourced from the same `sonatypeUsername` and `sonatypePassword` properties.

https://claude.ai/code/session_0185eQCsjR2uRsGWn2JpU9Xr