### PR TITLE
Update snapshot repository badge to use central.sonatype.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![build](https://github.com/ksletmoe/Bucket4k/actions/workflows/build.yml/badge.svg)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://github.com/ksletmoe/Bucket4k/blob/mainline/LICENSE)
 [![Maven Central](https://img.shields.io/maven-central/v/com.sletmoe.bucket4k/bucket4k.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.sletmoe.bucket4k%22%20AND%20a:%22bucket4k%22)
-[<img src="https://img.shields.io/nexus/s/https/s01.oss.sonatype.org/com.sletmoe.bucket4k/bucket4k.svg?label=latest%20snapshot&style=plastic"/>](https://s01.oss.sonatype.org/content/repositories/snapshots/com/sletmoe/bucket4k/bucket4k/)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https://central.sonatype.com/repository/maven-snapshots/com/sletmoe/bucket4k/bucket4k/maven-metadata.xml&label=latest%20snapshot&style=plastic"/>](https://central.sonatype.com/repository/maven-snapshots/com/sletmoe/bucket4k/bucket4k/)
 
 
 A Kotlin wrapper around [Bucket4j](https://github.com/bucket4j/bucket4j) which suspends and plays nicely with coroutines.


### PR DESCRIPTION
## Summary
Updated the Maven snapshot repository badge and link in the README to reflect the migration from the legacy Sonatype OSS repository to the new Sonatype Central repository.

## Changes
- Updated the snapshot badge image URL to use the new `central.sonatype.com` server endpoint
- Changed the badge link destination from `s01.oss.sonatype.org` to `central.sonatype.com/repository/maven-snapshots`
- Simplified the badge URL format to use the new Sonatype shields.io endpoint syntax

This change ensures that users are directed to the correct snapshot repository location following Sonatype's repository migration.

https://claude.ai/code/session_0142gq6QvrbYqMT4voo9XmCA